### PR TITLE
Add a flag for specifying which scanners to configure with the scanner configuration

### DIFF
--- a/kotlin-data-wedge-lib/src/main/java/dk/gls/kdw/model/barcode/ScannerConfiguration.kt
+++ b/kotlin-data-wedge-lib/src/main/java/dk/gls/kdw/model/barcode/ScannerConfiguration.kt
@@ -6,6 +6,8 @@ import dk.gls.kdw.model.inputParameters.AutoSwitchToDefaultOnEvent
 
 data class ScannerConfiguration(
     val scannerSelection: ScannerIdentifier = ScannerIdentifier.AUTO,
+    /** Specify which scanner the configurations apply to **/
+    val configureAllScanners : Boolean = true,
     val inputEnabled: Boolean = true,
     val autoSwitchToDefaultOnEvent: AutoSwitchToDefaultOnEvent = AutoSwitchToDefaultOnEvent.DISABLED,
 )
@@ -14,6 +16,7 @@ fun ScannerConfiguration.toBundle(): Bundle {
     return Bundle().apply {
         this.putString("scanner_selection", scannerSelection.toString())
         this.putBoolean("scanner_input_enabled", inputEnabled)
+        this.putString("configure_all_scanners", configureAllScanners.toString())
         this.putString("auto_switch_to_default_on_event", autoSwitchToDefaultOnEvent.value.toString())
     }
 }


### PR DESCRIPTION
In order for our scanner configuration to apply to newly connected scanners like the RS5100 we need this additional parameter.